### PR TITLE
feat: expand model catalog and reuse datasets

### DIFF
--- a/app/data/open_source_models.json
+++ b/app/data/open_source_models.json
@@ -1,0 +1,1460 @@
+[
+  {
+    "id": "alst/llama3-8b-deepspeed-alst",
+    "family": "alst",
+    "family_label": "Alst",
+    "label": "Alst \u2022 Llama 3.1 8B",
+    "base_model": "meta-llama/Llama-3.1-8B",
+    "default_suffix": "8b",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/alst/llama3-8b-deepspeed-alst.yaml"
+  },
+  {
+    "id": "alst/llama3-8b-fsdp2-alst",
+    "family": "alst",
+    "family_label": "Alst",
+    "label": "Alst \u2022 Llama 3.1 8B",
+    "base_model": "meta-llama/Llama-3.1-8B",
+    "default_suffix": "fsdp2",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/alst/llama3-8b-fsdp2-alst.yaml"
+  },
+  {
+    "id": "apertus/apertus-8b-qlora",
+    "family": "apertus",
+    "family_label": "Apertus",
+    "label": "Apertus \u2022 Apertus 8B Instruct 2509",
+    "base_model": "swiss-ai/Apertus-8B-Instruct-2509",
+    "default_suffix": "8b",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/apertus/apertus-8b-qlora.yaml"
+  },
+  {
+    "id": "arcee/afm-4.5b-qlora",
+    "family": "arcee",
+    "family_label": "Arcee",
+    "label": "Arcee \u2022 AFM 4.5B",
+    "base_model": "arcee-ai/AFM-4.5B",
+    "default_suffix": "4.5b",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/arcee/afm-4.5b-qlora.yaml"
+  },
+  {
+    "id": "archived/cerebras/btlm-ft",
+    "family": "archived",
+    "family_label": "Archived",
+    "label": "Archived \u2022 Btlm 3B 8K Base",
+    "base_model": "cerebras/btlm-3b-8k-base",
+    "default_suffix": "ft",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/archived/cerebras/btlm-ft.yml"
+  },
+  {
+    "id": "archived/cerebras/qlora",
+    "family": "archived",
+    "family_label": "Archived",
+    "label": "Archived \u2022 Cerebras GPT 1.3B",
+    "base_model": "cerebras/Cerebras-GPT-1.3B",
+    "default_suffix": "qlora",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/archived/cerebras/qlora.yml"
+  },
+  {
+    "id": "archived/code-llama/13b/lora",
+    "family": "archived",
+    "family_label": "Archived",
+    "label": "Archived \u2022 Codellama 13B Hf",
+    "base_model": "codellama/CodeLlama-13b-hf",
+    "default_suffix": "lora",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/archived/code-llama/13b/lora.yml"
+  },
+  {
+    "id": "archived/code-llama/13b/qlora",
+    "family": "archived",
+    "family_label": "Archived",
+    "label": "Archived \u2022 Codellama 13B Hf",
+    "base_model": "codellama/CodeLlama-13b-hf",
+    "default_suffix": "qlora",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/archived/code-llama/13b/qlora.yml"
+  },
+  {
+    "id": "archived/code-llama/34b/lora",
+    "family": "archived",
+    "family_label": "Archived",
+    "label": "Archived \u2022 Codellama 34B Hf",
+    "base_model": "codellama/CodeLlama-34b-hf",
+    "default_suffix": "lora",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/archived/code-llama/34b/lora.yml"
+  },
+  {
+    "id": "archived/code-llama/34b/qlora",
+    "family": "archived",
+    "family_label": "Archived",
+    "label": "Archived \u2022 Codellama 34B Hf",
+    "base_model": "codellama/CodeLlama-34b-hf",
+    "default_suffix": "qlora",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/archived/code-llama/34b/qlora.yml"
+  },
+  {
+    "id": "archived/code-llama/7b/lora",
+    "family": "archived",
+    "family_label": "Archived",
+    "label": "Archived \u2022 Codellama 7B Hf",
+    "base_model": "codellama/CodeLlama-7b-hf",
+    "default_suffix": "lora",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/archived/code-llama/7b/lora.yml"
+  },
+  {
+    "id": "archived/code-llama/7b/qlora",
+    "family": "archived",
+    "family_label": "Archived",
+    "label": "Archived \u2022 Codellama 7B Hf",
+    "base_model": "codellama/CodeLlama-7b-hf",
+    "default_suffix": "qlora",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/archived/code-llama/7b/qlora.yml"
+  },
+  {
+    "id": "archived/dbrx/16bit-lora",
+    "family": "archived",
+    "family_label": "Archived",
+    "label": "Archived \u2022 Dbrx Base Converted V2",
+    "base_model": "LnL-AI/dbrx-base-converted-v2",
+    "default_suffix": "16bit",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/archived/dbrx/16bit-lora.yaml"
+  },
+  {
+    "id": "archived/dbrx/8bit-lora",
+    "family": "archived",
+    "family_label": "Archived",
+    "label": "Archived \u2022 Dbrx Base Converted V2",
+    "base_model": "LnL-AI/dbrx-base-converted-v2",
+    "default_suffix": "8bit",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/archived/dbrx/8bit-lora.yaml"
+  },
+  {
+    "id": "archived/dbrx/fft-ds-zero3",
+    "family": "archived",
+    "family_label": "Archived",
+    "label": "Archived \u2022 Dbrx Base Converted V2",
+    "base_model": "LnL-AI/dbrx-base-converted-v2",
+    "default_suffix": "zero3",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/archived/dbrx/fft-ds-zero3.yaml"
+  },
+  {
+    "id": "archived/deepcoder/deepcoder-14B-preview-lora",
+    "family": "archived",
+    "family_label": "Archived",
+    "label": "Archived \u2022 Deepcoder 14B Preview",
+    "base_model": "agentica-org/DeepCoder-14B-Preview",
+    "default_suffix": "14B",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/archived/deepcoder/deepcoder-14B-preview-lora.yml"
+  },
+  {
+    "id": "archived/falcon/config-7b-lora",
+    "family": "archived",
+    "family_label": "Archived",
+    "label": "Archived \u2022 Falcon 7B",
+    "base_model": "tiiuae/falcon-7b",
+    "default_suffix": "7b",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/archived/falcon/config-7b-lora.yml"
+  },
+  {
+    "id": "archived/falcon/config-7b-qlora",
+    "family": "archived",
+    "family_label": "Archived",
+    "label": "Archived \u2022 Falcon 7B",
+    "base_model": "tiiuae/falcon-7b",
+    "default_suffix": "7b",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/archived/falcon/config-7b-qlora.yml"
+  },
+  {
+    "id": "archived/falcon/config-7b",
+    "family": "archived",
+    "family_label": "Archived",
+    "label": "Archived \u2022 Falcon 7B",
+    "base_model": "tiiuae/falcon-7b",
+    "default_suffix": "7b",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/archived/falcon/config-7b.yml"
+  },
+  {
+    "id": "archived/gemma/qlora",
+    "family": "archived",
+    "family_label": "Archived",
+    "label": "Archived \u2022 Gemma 7B",
+    "base_model": "mhenrichsen/gemma-7b",
+    "default_suffix": "qlora",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/archived/gemma/qlora.yml"
+  },
+  {
+    "id": "archived/gptj/qlora",
+    "family": "archived",
+    "family_label": "Archived",
+    "label": "Archived \u2022 Gpt J 6B",
+    "base_model": "EleutherAI/gpt-j-6b",
+    "default_suffix": "qlora",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/archived/gptj/qlora.yml"
+  },
+  {
+    "id": "archived/jeopardy-bot/config",
+    "family": "archived",
+    "family_label": "Archived",
+    "label": "Archived \u2022 Llama 7B",
+    "base_model": "huggyllama/llama-7b",
+    "default_suffix": "config",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/archived/jeopardy-bot/config.yml"
+  },
+  {
+    "id": "archived/mpt-7b/config",
+    "family": "archived",
+    "family_label": "Archived",
+    "label": "Archived \u2022 Mpt 7B",
+    "base_model": "mosaicml/mpt-7b",
+    "default_suffix": "config",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/archived/mpt-7b/config.yml"
+  },
+  {
+    "id": "archived/openllama-3b/config",
+    "family": "archived",
+    "family_label": "Archived",
+    "label": "Archived \u2022 Open Llama 3B V2",
+    "base_model": "openlm-research/open_llama_3b_v2",
+    "default_suffix": "config",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/archived/openllama-3b/config.yml"
+  },
+  {
+    "id": "archived/openllama-3b/lora",
+    "family": "archived",
+    "family_label": "Archived",
+    "label": "Archived \u2022 Open Llama 3B V2",
+    "base_model": "openlm-research/open_llama_3b_v2",
+    "default_suffix": "lora",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/archived/openllama-3b/lora.yml"
+  },
+  {
+    "id": "archived/openllama-3b/qlora",
+    "family": "archived",
+    "family_label": "Archived",
+    "label": "Archived \u2022 Open Llama 3B V2",
+    "base_model": "openlm-research/open_llama_3b_v2",
+    "default_suffix": "qlora",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/archived/openllama-3b/qlora.yml"
+  },
+  {
+    "id": "archived/pythia/lora",
+    "family": "archived",
+    "family_label": "Archived",
+    "label": "Archived \u2022 Pythia 1.4B Deduped",
+    "base_model": "EleutherAI/pythia-1.4b-deduped",
+    "default_suffix": "lora",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/archived/pythia/lora.yml"
+  },
+  {
+    "id": "archived/pythia-12b/config",
+    "family": "archived",
+    "family_label": "Archived",
+    "label": "Archived \u2022 Pythia 12B Deduped",
+    "base_model": "EleutherAI/pythia-12b-deduped",
+    "default_suffix": "config",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/archived/pythia-12b/config.yml"
+  },
+  {
+    "id": "archived/qwen/lora",
+    "family": "archived",
+    "family_label": "Archived",
+    "label": "Archived \u2022 Qwen 7B",
+    "base_model": "Qwen/Qwen-7B",
+    "default_suffix": "lora",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/archived/qwen/lora.yml"
+  },
+  {
+    "id": "archived/qwen/qlora",
+    "family": "archived",
+    "family_label": "Archived",
+    "label": "Archived \u2022 Qwen 7B",
+    "base_model": "Qwen/Qwen-7B",
+    "default_suffix": "qlora",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/archived/qwen/qlora.yml"
+  },
+  {
+    "id": "archived/qwen/qwen2-moe-lora",
+    "family": "archived",
+    "family_label": "Archived",
+    "label": "Archived \u2022 QWEN1.5 Moe A2.7B",
+    "base_model": "Qwen/Qwen1.5-MoE-A2.7B",
+    "default_suffix": "qwen2",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/archived/qwen/qwen2-moe-lora.yaml"
+  },
+  {
+    "id": "archived/qwen/qwen2-moe-qlora",
+    "family": "archived",
+    "family_label": "Archived",
+    "label": "Archived \u2022 QWEN1.5 Moe A2.7B",
+    "base_model": "Qwen/Qwen1.5-MoE-A2.7B",
+    "default_suffix": "qwen2",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/archived/qwen/qwen2-moe-qlora.yaml"
+  },
+  {
+    "id": "archived/redpajama/config-3b",
+    "family": "archived",
+    "family_label": "Archived",
+    "label": "Archived \u2022 Redpajama INCITE Chat 3B V1",
+    "base_model": "togethercomputer/RedPajama-INCITE-Chat-3B-v1",
+    "default_suffix": "3b",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/archived/redpajama/config-3b.yml"
+  },
+  {
+    "id": "archived/replit-3b/config-lora",
+    "family": "archived",
+    "family_label": "Archived",
+    "label": "Archived \u2022 Replit Code V1 3B",
+    "base_model": "replit/replit-code-v1-3b",
+    "default_suffix": "lora",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/archived/replit-3b/config-lora.yml"
+  },
+  {
+    "id": "archived/stablelm-2/1.6b/fft",
+    "family": "archived",
+    "family_label": "Archived",
+    "label": "Archived \u2022 Stablelm 2 1 6B",
+    "base_model": "stabilityai/stablelm-2-1_6b",
+    "default_suffix": "fft",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/archived/stablelm-2/1.6b/fft.yml"
+  },
+  {
+    "id": "archived/stablelm-2/1.6b/lora",
+    "family": "archived",
+    "family_label": "Archived",
+    "label": "Archived \u2022 Stablelm 2 1 6B",
+    "base_model": "stabilityai/stablelm-2-1_6b",
+    "default_suffix": "lora",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/archived/stablelm-2/1.6b/lora.yml"
+  },
+  {
+    "id": "archived/starcoder2/qlora",
+    "family": "archived",
+    "family_label": "Archived",
+    "label": "Archived \u2022 STARCODER2 3B",
+    "base_model": "bigcode/starcoder2-3b",
+    "default_suffix": "qlora",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/archived/starcoder2/qlora.yml"
+  },
+  {
+    "id": "archived/tiny-llama/pretrain",
+    "family": "archived",
+    "family_label": "Archived",
+    "label": "Archived \u2022 Tinyllama 1.1B Chat V1.0",
+    "base_model": "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
+    "default_suffix": "pretrain",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/archived/tiny-llama/pretrain.yml"
+  },
+  {
+    "id": "archived/tiny-llama/lora-mps",
+    "family": "archived",
+    "family_label": "Archived",
+    "label": "Archived \u2022 Tinyllama V1.1",
+    "base_model": "TinyLlama/TinyLlama_v1.1",
+    "default_suffix": "mps",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/archived/tiny-llama/lora-mps.yml"
+  },
+  {
+    "id": "archived/tiny-llama/lora",
+    "family": "archived",
+    "family_label": "Archived",
+    "label": "Archived \u2022 Tinyllama V1.1",
+    "base_model": "TinyLlama/TinyLlama_v1.1",
+    "default_suffix": "lora",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/archived/tiny-llama/lora.yml"
+  },
+  {
+    "id": "archived/tiny-llama/qlora",
+    "family": "archived",
+    "family_label": "Archived",
+    "label": "Archived \u2022 Tinyllama V1.1",
+    "base_model": "TinyLlama/TinyLlama_v1.1",
+    "default_suffix": "qlora",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/archived/tiny-llama/qlora.yml"
+  },
+  {
+    "id": "archived/xgen-7b/xgen-7b-8k-qlora",
+    "family": "archived",
+    "family_label": "Archived",
+    "label": "Archived \u2022 Xgen 7B 8K Base",
+    "base_model": "Salesforce/xgen-7b-8k-base",
+    "default_suffix": "8k",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/archived/xgen-7b/xgen-7b-8k-qlora.yml"
+  },
+  {
+    "id": "archived/yi-34B-chat/qlora",
+    "family": "archived",
+    "family_label": "Archived",
+    "label": "Archived \u2022 Yi 34B Chat",
+    "base_model": "01-ai/Yi-34B-Chat",
+    "default_suffix": "qlora",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/archived/yi-34B-chat/qlora.yml"
+  },
+  {
+    "id": "cloud/baseten",
+    "family": "cloud",
+    "family_label": "Cloud",
+    "label": "Cloud \u2022 Baseten",
+    "base_model": null,
+    "default_suffix": "baseten",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/cloud/baseten.yaml"
+  },
+  {
+    "id": "cloud/modal",
+    "family": "cloud",
+    "family_label": "Cloud",
+    "label": "Cloud \u2022 Modal",
+    "base_model": null,
+    "default_suffix": "modal",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/cloud/modal.yaml"
+  },
+  {
+    "id": "cohere/command-r-7b-qlora",
+    "family": "cohere",
+    "family_label": "Cohere",
+    "label": "Cohere \u2022 C4AI Command R7B 12 2024",
+    "base_model": "CohereForAI/c4ai-command-r7b-12-2024",
+    "default_suffix": "7b",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/cohere/command-r-7b-qlora.yml"
+  },
+  {
+    "id": "deepcogito/cogito-v1-preview-llama-3B-lora",
+    "family": "deepcogito",
+    "family_label": "Deepcogito",
+    "label": "Deepcogito \u2022 Cogito V1 Preview Llama 3B",
+    "base_model": "deepcogito/cogito-v1-preview-llama-3B",
+    "default_suffix": "3B",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/deepcogito/cogito-v1-preview-llama-3B-lora.yml"
+  },
+  {
+    "id": "deepcogito/cogito-v1-preview-qwen-14B-lora",
+    "family": "deepcogito",
+    "family_label": "Deepcogito",
+    "label": "Deepcogito \u2022 Cogito V1 Preview Qwen 14B",
+    "base_model": "deepcogito/cogito-v1-preview-qwen-14B",
+    "default_suffix": "14B",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/deepcogito/cogito-v1-preview-qwen-14B-lora.yml"
+  },
+  {
+    "id": "deepseek-v2/fft-fsdp-16b",
+    "family": "deepseek-v2",
+    "family_label": "Deepseek V2",
+    "label": "Deepseek V2 \u2022 Deepseek V2 Lite",
+    "base_model": "deepseek-ai/DeepSeek-V2-Lite",
+    "default_suffix": "16b",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/deepseek-v2/fft-fsdp-16b.yaml"
+  },
+  {
+    "id": "deepseek-v2/qlora-fsdp-2_5",
+    "family": "deepseek-v2",
+    "family_label": "Deepseek V2",
+    "label": "Deepseek V2 \u2022 Deepseek V2.5 Bnb NF4 BF16",
+    "base_model": "axolotl-quants/DeepSeek-V2.5-bnb-nf4-bf16",
+    "default_suffix": "5",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/deepseek-v2/qlora-fsdp-2_5.yaml"
+  },
+  {
+    "id": "devstral/devstral-small-qlora",
+    "family": "devstral",
+    "family_label": "Devstral",
+    "label": "Devstral \u2022 Devstral Small 2507",
+    "base_model": "mistralai/Devstral-Small-2507",
+    "default_suffix": "qlora",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/devstral/devstral-small-qlora.yml"
+  },
+  {
+    "id": "distributed-parallel/llama-3_1-8b-hsdp-tp",
+    "family": "distributed-parallel",
+    "family_label": "Distributed Parallel",
+    "label": "Distributed Parallel \u2022 Llama 3.1 8B",
+    "base_model": "meta-llama/Llama-3.1-8B",
+    "default_suffix": "8b",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/distributed-parallel/llama-3_1-8b-hsdp-tp.yaml"
+  },
+  {
+    "id": "distributed-parallel/qwen3-8b-fsdp-tp-cp",
+    "family": "distributed-parallel",
+    "family_label": "Distributed Parallel",
+    "label": "Distributed Parallel \u2022 QWEN3 8B",
+    "base_model": "Qwen/Qwen3-8B",
+    "default_suffix": "8b",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/distributed-parallel/qwen3-8b-fsdp-tp-cp.yaml"
+  },
+  {
+    "id": "falcon-h1/falcon-h1-500m-qlora",
+    "family": "falcon-h1",
+    "family_label": "Falcon H1",
+    "label": "Falcon H1 \u2022 Falcon H1 0.5B Instruct",
+    "base_model": "tiiuae/Falcon-H1-0.5B-Instruct",
+    "default_suffix": "500m",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/falcon-h1/falcon-h1-500m-qlora.yaml"
+  },
+  {
+    "id": "falcon-h1/falcon-h1-1b-qlora",
+    "family": "falcon-h1",
+    "family_label": "Falcon H1",
+    "label": "Falcon H1 \u2022 Falcon H1 1.5B Base",
+    "base_model": "tiiuae/Falcon-H1-1.5B-Base",
+    "default_suffix": "1b",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/falcon-h1/falcon-h1-1b-qlora.yaml"
+  },
+  {
+    "id": "falcon-h1/falcon-h1-1b-deep-qlora",
+    "family": "falcon-h1",
+    "family_label": "Falcon H1",
+    "label": "Falcon H1 \u2022 Falcon H1 1.5B Deep Base",
+    "base_model": "tiiuae/Falcon-H1-1.5B-Deep-Base",
+    "default_suffix": "1b",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/falcon-h1/falcon-h1-1b-deep-qlora.yaml"
+  },
+  {
+    "id": "falcon-h1/falcon-h1-34b-qlora",
+    "family": "falcon-h1",
+    "family_label": "Falcon H1",
+    "label": "Falcon H1 \u2022 Falcon H1 34B Base",
+    "base_model": "tiiuae/Falcon-H1-34B-Base",
+    "default_suffix": "34b",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/falcon-h1/falcon-h1-34b-qlora.yaml"
+  },
+  {
+    "id": "falcon-h1/falcon-h1-3b-qlora",
+    "family": "falcon-h1",
+    "family_label": "Falcon H1",
+    "label": "Falcon H1 \u2022 Falcon H1 3B Base",
+    "base_model": "tiiuae/Falcon-H1-3B-Base",
+    "default_suffix": "3b",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/falcon-h1/falcon-h1-3b-qlora.yaml"
+  },
+  {
+    "id": "falcon-h1/falcon-h1-7b-qlora",
+    "family": "falcon-h1",
+    "family_label": "Falcon H1",
+    "label": "Falcon H1 \u2022 Falcon H1 7B Base",
+    "base_model": "tiiuae/Falcon-H1-7B-Base",
+    "default_suffix": "7b",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/falcon-h1/falcon-h1-7b-qlora.yaml"
+  },
+  {
+    "id": "gemma2/reward-model",
+    "family": "gemma2",
+    "family_label": "GEMMA2",
+    "label": "GEMMA2 \u2022 Gemma 2 2B",
+    "base_model": "google/gemma-2-2b",
+    "default_suffix": "model",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/gemma2/reward-model.yaml"
+  },
+  {
+    "id": "gemma2/qlora",
+    "family": "gemma2",
+    "family_label": "GEMMA2",
+    "label": "GEMMA2 \u2022 Gemma 2 9B",
+    "base_model": "google/gemma-2-9b",
+    "default_suffix": "qlora",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/gemma2/qlora.yml"
+  },
+  {
+    "id": "gemma3/gemma-3-1b-qlora",
+    "family": "gemma3",
+    "family_label": "GEMMA3",
+    "label": "GEMMA3 \u2022 Gemma 3 1B It",
+    "base_model": "google/gemma-3-1b-it",
+    "default_suffix": "1b",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/gemma3/gemma-3-1b-qlora.yml"
+  },
+  {
+    "id": "gemma3/gemma-3-270m-qlora",
+    "family": "gemma3",
+    "family_label": "GEMMA3",
+    "label": "GEMMA3 \u2022 Gemma 3 270M It",
+    "base_model": "google/gemma-3-270m-it",
+    "default_suffix": "270m",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/gemma3/gemma-3-270m-qlora.yml"
+  },
+  {
+    "id": "gemma3/gemma-3-4b-qlora",
+    "family": "gemma3",
+    "family_label": "GEMMA3",
+    "label": "GEMMA3 \u2022 Gemma 3 4B It",
+    "base_model": "google/gemma-3-4b-it",
+    "default_suffix": "4b",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/gemma3/gemma-3-4b-qlora.yml"
+  },
+  {
+    "id": "gemma3/gemma-3-4b-vision-qlora",
+    "family": "gemma3",
+    "family_label": "GEMMA3",
+    "label": "GEMMA3 \u2022 Gemma 3 4B It",
+    "base_model": "google/gemma-3-4b-it",
+    "default_suffix": "4b",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/gemma3/gemma-3-4b-vision-qlora.yml"
+  },
+  {
+    "id": "gemma3n/gemma-3n-e2b-qlora",
+    "family": "gemma3n",
+    "family_label": "GEMMA3N",
+    "label": "GEMMA3N \u2022 Gemma 3N E2B It",
+    "base_model": "google/gemma-3n-E2B-it",
+    "default_suffix": "e2b",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/gemma3n/gemma-3n-e2b-qlora.yml"
+  },
+  {
+    "id": "gemma3n/gemma-3n-e2b-vision-audio-qlora",
+    "family": "gemma3n",
+    "family_label": "GEMMA3N",
+    "label": "GEMMA3N \u2022 Gemma 3N E2B It",
+    "base_model": "google/gemma-3n-E2B-it",
+    "default_suffix": "e2b",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/gemma3n/gemma-3n-e2b-vision-audio-qlora.yml"
+  },
+  {
+    "id": "gemma3n/gemma-3n-e2b-vision-qlora",
+    "family": "gemma3n",
+    "family_label": "GEMMA3N",
+    "label": "GEMMA3N \u2022 Gemma 3N E2B It",
+    "base_model": "google/gemma-3n-E2B-it",
+    "default_suffix": "e2b",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/gemma3n/gemma-3n-e2b-vision-qlora.yml"
+  },
+  {
+    "id": "glm4/qlora-32b",
+    "family": "glm4",
+    "family_label": "GLM4",
+    "label": "GLM4 \u2022 GLM 4 32B 0414",
+    "base_model": "THUDM/GLM-4-32B-0414",
+    "default_suffix": "32b",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/glm4/qlora-32b.yaml"
+  },
+  {
+    "id": "gpt-oss/gpt-oss-120b-fft-fsdp2-offload",
+    "family": "gpt-oss",
+    "family_label": "Gpt Oss",
+    "label": "Gpt Oss \u2022 Gpt Oss 120B Dequantized",
+    "base_model": "axolotl-ai-co/gpt-oss-120b-dequantized",
+    "default_suffix": "fsdp2",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/gpt-oss/gpt-oss-120b-fft-fsdp2-offload.yaml"
+  },
+  {
+    "id": "gpt-oss/gpt-oss-20b-fft-deepspeed-zero3",
+    "family": "gpt-oss",
+    "family_label": "Gpt Oss",
+    "label": "Gpt Oss \u2022 Gpt Oss 20B",
+    "base_model": "openai/gpt-oss-20b",
+    "default_suffix": "zero3",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/gpt-oss/gpt-oss-20b-fft-deepspeed-zero3.yaml"
+  },
+  {
+    "id": "gpt-oss/gpt-oss-20b-fft-fsdp2-offload",
+    "family": "gpt-oss",
+    "family_label": "Gpt Oss",
+    "label": "Gpt Oss \u2022 Gpt Oss 20B",
+    "base_model": "openai/gpt-oss-20b",
+    "default_suffix": "fsdp2",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/gpt-oss/gpt-oss-20b-fft-fsdp2-offload.yaml"
+  },
+  {
+    "id": "gpt-oss/gpt-oss-20b-fft-fsdp2",
+    "family": "gpt-oss",
+    "family_label": "Gpt Oss",
+    "label": "Gpt Oss \u2022 Gpt Oss 20B",
+    "base_model": "openai/gpt-oss-20b",
+    "default_suffix": "fsdp2",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/gpt-oss/gpt-oss-20b-fft-fsdp2.yaml"
+  },
+  {
+    "id": "gpt-oss/gpt-oss-20b-sft-lora-singlegpu",
+    "family": "gpt-oss",
+    "family_label": "Gpt Oss",
+    "label": "Gpt Oss \u2022 Gpt Oss 20B",
+    "base_model": "openai/gpt-oss-20b",
+    "default_suffix": "20b",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/gpt-oss/gpt-oss-20b-sft-lora-singlegpu.yaml"
+  },
+  {
+    "id": "hunyuan/hunyuan-v1-dense-qlora",
+    "family": "hunyuan",
+    "family_label": "Hunyuan",
+    "label": "Hunyuan \u2022 Hunyuan 0.5B Instruct",
+    "base_model": "tencent/Hunyuan-0.5B-Instruct",
+    "default_suffix": "v1",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/hunyuan/hunyuan-v1-dense-qlora.yaml"
+  },
+  {
+    "id": "jamba/qlora_fsdp_large",
+    "family": "jamba",
+    "family_label": "Jamba",
+    "label": "Jamba \u2022 AI21 Jamba 1.5 Large",
+    "base_model": "ai21labs/AI21-Jamba-1.5-Large",
+    "default_suffix": "large",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/jamba/qlora_fsdp_large.yaml"
+  },
+  {
+    "id": "jamba/qlora",
+    "family": "jamba",
+    "family_label": "Jamba",
+    "label": "Jamba \u2022 Jamba V0.1",
+    "base_model": "ai21labs/Jamba-v0.1",
+    "default_suffix": "qlora",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/jamba/qlora.yaml"
+  },
+  {
+    "id": "jamba/qlora_deepspeed",
+    "family": "jamba",
+    "family_label": "Jamba",
+    "label": "Jamba \u2022 Jamba V0.1",
+    "base_model": "ai21labs/Jamba-v0.1",
+    "default_suffix": "deepspeed",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/jamba/qlora_deepspeed.yaml"
+  },
+  {
+    "id": "LiquidAI/lfm2-350m-fft",
+    "family": "LiquidAI",
+    "family_label": "Liquidai",
+    "label": "Liquidai \u2022 LFM2 350M",
+    "base_model": "LiquidAI/LFM2-350M",
+    "default_suffix": "350m",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/LiquidAI/lfm2-350m-fft.yaml"
+  },
+  {
+    "id": "LiquidAI/lfm2-vl-lora",
+    "family": "LiquidAI",
+    "family_label": "Liquidai",
+    "label": "Liquidai \u2022 LFM2 VL 450M",
+    "base_model": "LiquidAI/LFM2-VL-450M",
+    "default_suffix": "lfm2",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/LiquidAI/lfm2-vl-lora.yaml"
+  },
+  {
+    "id": "llama-2/gptq-lora",
+    "family": "llama-2",
+    "family_label": "Llama 2",
+    "label": "Llama 2 \u2022 Llama 2 7B GPTQ",
+    "base_model": "TheBloke/Llama-2-7B-GPTQ",
+    "default_suffix": "lora",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/llama-2/gptq-lora.yml"
+  },
+  {
+    "id": "llama-2/fft_optimized",
+    "family": "llama-2",
+    "family_label": "Llama 2",
+    "label": "Llama 2 \u2022 Llama 2 7B Hf",
+    "base_model": "NousResearch/Llama-2-7b-hf",
+    "default_suffix": "optimized",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/llama-2/fft_optimized.yml"
+  },
+  {
+    "id": "llama-2/lisa",
+    "family": "llama-2",
+    "family_label": "Llama 2",
+    "label": "Llama 2 \u2022 Llama 2 7B Hf",
+    "base_model": "NousResearch/Llama-2-7b-hf",
+    "default_suffix": "lisa",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/llama-2/lisa.yml"
+  },
+  {
+    "id": "llama-2/loftq",
+    "family": "llama-2",
+    "family_label": "Llama 2",
+    "label": "Llama 2 \u2022 Llama 2 7B Hf",
+    "base_model": "NousResearch/Llama-2-7b-hf",
+    "default_suffix": "loftq",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/llama-2/loftq.yml"
+  },
+  {
+    "id": "llama-2/lora",
+    "family": "llama-2",
+    "family_label": "Llama 2",
+    "label": "Llama 2 \u2022 Llama 2 7B Hf",
+    "base_model": "NousResearch/Llama-2-7b-hf",
+    "default_suffix": "lora",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/llama-2/lora.yml"
+  },
+  {
+    "id": "llama-2/qlora-fsdp",
+    "family": "llama-2",
+    "family_label": "Llama 2",
+    "label": "Llama 2 \u2022 Llama 2 7B Hf",
+    "base_model": "NousResearch/Llama-2-7b-hf",
+    "default_suffix": "fsdp",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/llama-2/qlora-fsdp.yml"
+  },
+  {
+    "id": "llama-2/qlora",
+    "family": "llama-2",
+    "family_label": "Llama 2",
+    "label": "Llama 2 \u2022 Llama 2 7B Hf",
+    "base_model": "NousResearch/Llama-2-7b-hf",
+    "default_suffix": "qlora",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/llama-2/qlora.yml"
+  },
+  {
+    "id": "llama-2/relora",
+    "family": "llama-2",
+    "family_label": "Llama 2",
+    "label": "Llama 2 \u2022 Llama 2 7B Hf",
+    "base_model": "NousResearch/Llama-2-7b-hf",
+    "default_suffix": "relora",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/llama-2/relora.yml"
+  },
+  {
+    "id": "llama-3/qlora-fsdp-70b",
+    "family": "llama-3",
+    "family_label": "Llama 3",
+    "label": "Llama 3 \u2022 Llama 3 70B FP16",
+    "base_model": "casperhansen/llama-3-70b-fp16",
+    "default_suffix": "70b",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/llama-3/qlora-fsdp-70b.yaml"
+  },
+  {
+    "id": "llama-3/diffusion/pretrain-1b",
+    "family": "llama-3",
+    "family_label": "Llama 3",
+    "label": "Llama 3 \u2022 Llama 3.2 1B",
+    "base_model": "meta-llama/Llama-3.2-1B",
+    "default_suffix": "1b",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/llama-3/diffusion/pretrain-1b.yaml"
+  },
+  {
+    "id": "llama-3/diffusion/sft-1b",
+    "family": "llama-3",
+    "family_label": "Llama 3",
+    "label": "Llama 3 \u2022 Llama 3.2 1B",
+    "base_model": "meta-llama/Llama-3.2-1B",
+    "default_suffix": "1b",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/llama-3/diffusion/sft-1b.yaml"
+  },
+  {
+    "id": "llama-3/lora-1b-deduplicate-dpo",
+    "family": "llama-3",
+    "family_label": "Llama 3",
+    "label": "Llama 3 \u2022 Llama 3.2 1B",
+    "base_model": "meta-llama/Llama-3.2-1B",
+    "default_suffix": "1b",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/llama-3/lora-1b-deduplicate-dpo.yml"
+  },
+  {
+    "id": "llama-3/lora-1b-deduplicate-sft",
+    "family": "llama-3",
+    "family_label": "Llama 3",
+    "label": "Llama 3 \u2022 Llama 3.2 1B",
+    "base_model": "meta-llama/Llama-3.2-1B",
+    "default_suffix": "1b",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/llama-3/lora-1b-deduplicate-sft.yml"
+  },
+  {
+    "id": "llama-3/lora-1b-kernels",
+    "family": "llama-3",
+    "family_label": "Llama 3",
+    "label": "Llama 3 \u2022 Llama 3.2 1B",
+    "base_model": "NousResearch/Llama-3.2-1B",
+    "default_suffix": "1b",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/llama-3/lora-1b-kernels.yml"
+  },
+  {
+    "id": "llama-3/lora-1b-ray",
+    "family": "llama-3",
+    "family_label": "Llama 3",
+    "label": "Llama 3 \u2022 Llama 3.2 1B",
+    "base_model": "NousResearch/Llama-3.2-1B",
+    "default_suffix": "1b",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/llama-3/lora-1b-ray.yml"
+  },
+  {
+    "id": "llama-3/lora-1b-sample-packing-sequentially",
+    "family": "llama-3",
+    "family_label": "Llama 3",
+    "label": "Llama 3 \u2022 Llama 3.2 1B",
+    "base_model": "meta-llama/Llama-3.2-1B",
+    "default_suffix": "1b",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/llama-3/lora-1b-sample-packing-sequentially.yml"
+  },
+  {
+    "id": "llama-3/lora-1b",
+    "family": "llama-3",
+    "family_label": "Llama 3",
+    "label": "Llama 3 \u2022 Llama 3.2 1B",
+    "base_model": "NousResearch/Llama-3.2-1B",
+    "default_suffix": "1b",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/llama-3/lora-1b.yml"
+  },
+  {
+    "id": "llama-3/qlora-1b-kto",
+    "family": "llama-3",
+    "family_label": "Llama 3",
+    "label": "Llama 3 \u2022 Llama 3.2 1B",
+    "base_model": "meta-llama/Llama-3.2-1B",
+    "default_suffix": "1b",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/llama-3/qlora-1b-kto.yaml"
+  },
+  {
+    "id": "llama-3/qlora-1b",
+    "family": "llama-3",
+    "family_label": "Llama 3",
+    "label": "Llama 3 \u2022 Llama 3.2 1B",
+    "base_model": "NousResearch/Llama-3.2-1B",
+    "default_suffix": "1b",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/llama-3/qlora-1b.yml"
+  },
+  {
+    "id": "llama-3/3b-fp8-fsdp2",
+    "family": "llama-3",
+    "family_label": "Llama 3",
+    "label": "Llama 3 \u2022 Llama 3.2 3B",
+    "base_model": "meta-llama/Llama-3.2-3B",
+    "default_suffix": "fsdp2",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/llama-3/3b-fp8-fsdp2.yaml"
+  },
+  {
+    "id": "llama-3/3b-qat-fsdp2",
+    "family": "llama-3",
+    "family_label": "Llama 3",
+    "label": "Llama 3 \u2022 Llama 3.2 3B",
+    "base_model": "meta-llama/Llama-3.2-3B",
+    "default_suffix": "fsdp2",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/llama-3/3b-qat-fsdp2.yaml"
+  },
+  {
+    "id": "llama-3/3b-qat-nvfp4",
+    "family": "llama-3",
+    "family_label": "Llama 3",
+    "label": "Llama 3 \u2022 Llama 3.2 3B",
+    "base_model": "meta-llama/Llama-3.2-3B",
+    "default_suffix": "nvfp4",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/llama-3/3b-qat-nvfp4.yaml"
+  },
+  {
+    "id": "llama-3/lora-8b",
+    "family": "llama-3",
+    "family_label": "Llama 3",
+    "label": "Llama 3 \u2022 Meta Llama 3 8B",
+    "base_model": "NousResearch/Meta-Llama-3-8B",
+    "default_suffix": "8b",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/llama-3/lora-8b.yml"
+  },
+  {
+    "id": "llama-3/qlora",
+    "family": "llama-3",
+    "family_label": "Llama 3",
+    "label": "Llama 3 \u2022 Meta Llama 3 8B",
+    "base_model": "NousResearch/Meta-Llama-3-8B",
+    "default_suffix": "qlora",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/llama-3/qlora.yml"
+  },
+  {
+    "id": "llama-3/instruct-dpo-lora-8b",
+    "family": "llama-3",
+    "family_label": "Llama 3",
+    "label": "Llama 3 \u2022 Meta Llama 3 8B Instruct",
+    "base_model": "meta-llama/Meta-Llama-3-8B-Instruct",
+    "default_suffix": "8b",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/llama-3/instruct-dpo-lora-8b.yml"
+  },
+  {
+    "id": "llama-3/instruct-lora-8b",
+    "family": "llama-3",
+    "family_label": "Llama 3",
+    "label": "Llama 3 \u2022 Meta Llama 3 8B Instruct",
+    "base_model": "NousResearch/Meta-Llama-3-8B-Instruct",
+    "default_suffix": "8b",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/llama-3/instruct-lora-8b.yml"
+  },
+  {
+    "id": "llama-3/qlora-fsdp-405b",
+    "family": "llama-3",
+    "family_label": "Llama 3",
+    "label": "Llama 3 \u2022 Meta Llama 3.1 405B BNB NF4 BF16",
+    "base_model": "hugging-quants/Meta-Llama-3.1-405B-BNB-NF4-BF16",
+    "default_suffix": "405b",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/llama-3/qlora-fsdp-405b.yaml"
+  },
+  {
+    "id": "llama-3/fft-8b-liger-fsdp",
+    "family": "llama-3",
+    "family_label": "Llama 3",
+    "label": "Llama 3 \u2022 Meta Llama 3.1 8B",
+    "base_model": "NousResearch/Meta-Llama-3.1-8B",
+    "default_suffix": "8b",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/llama-3/fft-8b-liger-fsdp.yaml"
+  },
+  {
+    "id": "llama-3/fft-8b",
+    "family": "llama-3",
+    "family_label": "Llama 3",
+    "label": "Llama 3 \u2022 Meta Llama 3.1 8B",
+    "base_model": "NousResearch/Meta-Llama-3.1-8B",
+    "default_suffix": "8b",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/llama-3/fft-8b.yaml"
+  },
+  {
+    "id": "llama-3/sparse-finetuning",
+    "family": "llama-3",
+    "family_label": "Llama 3",
+    "label": "Llama 3 \u2022 Sparse Llama 3.1 8B 2OF4",
+    "base_model": "neuralmagic/Sparse-Llama-3.1-8B-2of4",
+    "default_suffix": "finetuning",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/llama-3/sparse-finetuning.yaml"
+  },
+  {
+    "id": "llama-3-vision/lora-11b",
+    "family": "llama-3-vision",
+    "family_label": "Llama 3 Vision",
+    "label": "Llama 3 Vision \u2022 Llama 3.2 11B Vision Instruct",
+    "base_model": "alpindale/Llama-3.2-11B-Vision-Instruct",
+    "default_suffix": "11b",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/llama-3-vision/lora-11b.yaml"
+  },
+  {
+    "id": "llama-4/do-no-use-fa2/maverick-qlora-fsdp1",
+    "family": "llama-4",
+    "family_label": "Llama 4",
+    "label": "Llama 4 \u2022 Llama 4 Maverick 17B 128E Linearized Bnb NF4 BF16",
+    "base_model": "axolotl-quants/Llama-4-Maverick-17B-128E-Linearized-bnb-nf4-bf16",
+    "default_suffix": "fsdp1",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/llama-4/do-no-use-fa2/maverick-qlora-fsdp1.yaml"
+  },
+  {
+    "id": "llama-4/do-no-use-fa2/scout-qlora-fsdp1",
+    "family": "llama-4",
+    "family_label": "Llama 4",
+    "label": "Llama 4 \u2022 Llama 4 Scout 17B 16E Linearized Bnb NF4 BF16",
+    "base_model": "axolotl-quants/Llama-4-Scout-17B-16E-Linearized-bnb-nf4-bf16",
+    "default_suffix": "fsdp1",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/llama-4/do-no-use-fa2/scout-qlora-fsdp1.yaml"
+  },
+  {
+    "id": "llama-4/do-no-use-fa2/scout-qlora-single-h100",
+    "family": "llama-4",
+    "family_label": "Llama 4",
+    "label": "Llama 4 \u2022 Llama 4 Scout 17B 16E Linearized Bnb NF4 BF16",
+    "base_model": "axolotl-quants/Llama-4-Scout-17B-16E-Linearized-bnb-nf4-bf16",
+    "default_suffix": "h100",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/llama-4/do-no-use-fa2/scout-qlora-single-h100.yaml"
+  },
+  {
+    "id": "llama-4/do-no-use-fa2/scout-vision-qlora-fsdp",
+    "family": "llama-4",
+    "family_label": "Llama 4",
+    "label": "Llama 4 \u2022 Llama 4 Scout 17B 16E Linearized Bnb NF4 BF16",
+    "base_model": "axolotl-quants/Llama-4-Scout-17B-16E-Linearized-bnb-nf4-bf16",
+    "default_suffix": "fsdp",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/llama-4/do-no-use-fa2/scout-vision-qlora-fsdp.yaml"
+  },
+  {
+    "id": "llama-4/scout-qlora-flexattn-fsdp2",
+    "family": "llama-4",
+    "family_label": "Llama 4",
+    "label": "Llama 4 \u2022 Llama 4 Scout 17B 16E Linearized Bnb NF4 BF16",
+    "base_model": "axolotl-quants/Llama-4-Scout-17B-16E-Linearized-bnb-nf4-bf16",
+    "default_suffix": "fsdp2",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/llama-4/scout-qlora-flexattn-fsdp2.yaml"
+  },
+  {
+    "id": "llama-4/scout-qlora-single-h100-flex",
+    "family": "llama-4",
+    "family_label": "Llama 4",
+    "label": "Llama 4 \u2022 Llama 4 Scout 17B 16E Linearized Bnb NF4 BF16",
+    "base_model": "axolotl-quants/Llama-4-Scout-17B-16E-Linearized-bnb-nf4-bf16",
+    "default_suffix": "h100",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/llama-4/scout-qlora-single-h100-flex.yaml"
+  },
+  {
+    "id": "llama-4/scout-vision-qlora-fsdp2-flex",
+    "family": "llama-4",
+    "family_label": "Llama 4",
+    "label": "Llama 4 \u2022 Llama 4 Scout 17B 16E Linearized Bnb NF4 BF16",
+    "base_model": "axolotl-quants/Llama-4-Scout-17B-16E-Linearized-bnb-nf4-bf16",
+    "default_suffix": "fsdp2",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/llama-4/scout-vision-qlora-fsdp2-flex.yaml"
+  },
+  {
+    "id": "llava/lora-7b",
+    "family": "llava",
+    "family_label": "Llava",
+    "label": "Llava \u2022 Llava 1.5 7B Hf",
+    "base_model": "llava-hf/llava-1.5-7b-hf",
+    "default_suffix": "7b",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/llava/lora-7b.yaml"
+  },
+  {
+    "id": "magistral/magistral-small-fsdp-qlora",
+    "family": "magistral",
+    "family_label": "Magistral",
+    "label": "Magistral \u2022 Magistral Small 2506",
+    "base_model": "mistralai/Magistral-Small-2506",
+    "default_suffix": "qlora",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/magistral/magistral-small-fsdp-qlora.yaml"
+  },
+  {
+    "id": "magistral/magistral-small-qlora",
+    "family": "magistral",
+    "family_label": "Magistral",
+    "label": "Magistral \u2022 Magistral Small 2506",
+    "base_model": "mistralai/Magistral-Small-2506",
+    "default_suffix": "qlora",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/magistral/magistral-small-qlora.yaml"
+  },
+  {
+    "id": "magistral/think/magistral-small-think-qlora",
+    "family": "magistral",
+    "family_label": "Magistral",
+    "label": "Magistral \u2022 Magistral Small 2507",
+    "base_model": "mistralai/Magistral-Small-2507",
+    "default_suffix": "qlora",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/magistral/think/magistral-small-think-qlora.yaml"
+  },
+  {
+    "id": "magistral/vision/magistral-small-vision-24B-qlora",
+    "family": "magistral",
+    "family_label": "Magistral",
+    "label": "Magistral \u2022 Magistral Small 2509",
+    "base_model": "mistralai/Magistral-Small-2509",
+    "default_suffix": "24B",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/magistral/vision/magistral-small-vision-24B-qlora.yml"
+  },
+  {
+    "id": "mamba/config",
+    "family": "mamba",
+    "family_label": "Mamba",
+    "label": "Mamba \u2022 Mamba 2.8B",
+    "base_model": "state-spaces/mamba-2.8b",
+    "default_suffix": "config",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/mamba/config.yml"
+  },
+  {
+    "id": "mistral/dpo/mistral-dpo-qlora",
+    "family": "mistral",
+    "family_label": "Mistral",
+    "label": "Mistral \u2022 Mistral 7B Instruct V0.2",
+    "base_model": "mistralai/Mistral-7B-Instruct-v0.2",
+    "default_suffix": "qlora",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/mistral/dpo/mistral-dpo-qlora.yml"
+  },
+  {
+    "id": "mistral/config",
+    "family": "mistral",
+    "family_label": "Mistral",
+    "label": "Mistral \u2022 Mistral 7B V0.1",
+    "base_model": "mistralai/Mistral-7B-v0.1",
+    "default_suffix": "config",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/mistral/config.yml"
+  },
+  {
+    "id": "mistral/lora",
+    "family": "mistral",
+    "family_label": "Mistral",
+    "label": "Mistral \u2022 Mistral 7B V0.1",
+    "base_model": "mistralai/Mistral-7B-v0.1",
+    "default_suffix": "lora",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/mistral/lora.yml"
+  },
+  {
+    "id": "mistral/mps/lora-mps",
+    "family": "mistral",
+    "family_label": "Mistral",
+    "label": "Mistral \u2022 Mistral 7B V0.1",
+    "base_model": "mistralai/Mistral-7B-v0.1",
+    "default_suffix": "mps",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/mistral/mps/lora-mps.yml"
+  },
+  {
+    "id": "mistral/orpo/mistral-qlora-orpo",
+    "family": "mistral",
+    "family_label": "Mistral",
+    "label": "Mistral \u2022 Mistral 7B V0.1",
+    "base_model": "mistralai/Mistral-7B-v0.1",
+    "default_suffix": "orpo",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/mistral/orpo/mistral-qlora-orpo.yml"
+  },
+  {
+    "id": "mistral/qlora",
+    "family": "mistral",
+    "family_label": "Mistral",
+    "label": "Mistral \u2022 Mistral 7B V0.1",
+    "base_model": "mistralai/Mistral-7B-v0.1",
+    "default_suffix": "qlora",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/mistral/qlora.yml"
+  },
+  {
+    "id": "mistral/mistral-small/mistral-small-3.1-24B-lora",
+    "family": "mistral",
+    "family_label": "Mistral",
+    "label": "Mistral \u2022 Mistral Small 3.1 24B Instruct 2503",
+    "base_model": "mistralai/Mistral-Small-3.1-24B-Instruct-2503",
+    "default_suffix": "24B",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/mistral/mistral-small/mistral-small-3.1-24B-lora.yml"
+  },
+  {
+    "id": "mistral/bigstral/bigstral-ds-zero3",
+    "family": "mistral",
+    "family_label": "Mistral",
+    "label": "Mistral \u2022 Mixtral 8X22B V0.1",
+    "base_model": "mistral-community/Mixtral-8x22B-v0.1",
+    "default_suffix": "zero3",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/mistral/bigstral/bigstral-ds-zero3.yaml"
+  },
+  {
+    "id": "mistral/mixtral/mixtral-8x22b-qlora-fsdp",
+    "family": "mistral",
+    "family_label": "Mistral",
+    "label": "Mistral \u2022 Mixtral 8X22B V0.1",
+    "base_model": "mistral-community/Mixtral-8x22B-v0.1",
+    "default_suffix": "8x22b",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/mistral/mixtral/mixtral-8x22b-qlora-fsdp.yml"
+  },
+  {
+    "id": "mistral/mixtral/mixtral_22",
+    "family": "mistral",
+    "family_label": "Mistral",
+    "label": "Mistral \u2022 Mixtral 8X22B V0.1",
+    "base_model": "mistral-community/Mixtral-8x22B-v0.1",
+    "default_suffix": "22",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/mistral/mixtral/mixtral_22.yml"
+  },
+  {
+    "id": "mistral/mistral-qlora-fsdp",
+    "family": "mistral",
+    "family_label": "Mistral",
+    "label": "Mistral \u2022 Mixtral 8X7B V0.1",
+    "base_model": "mistralai/Mixtral-8x7B-v0.1",
+    "default_suffix": "fsdp",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/mistral/mistral-qlora-fsdp.yml"
+  },
+  {
+    "id": "mistral/mixtral/mixtral-qlora-fsdp",
+    "family": "mistral",
+    "family_label": "Mistral",
+    "label": "Mistral \u2022 Mixtral 8X7B V0.1",
+    "base_model": "mistralai/Mixtral-8x7B-v0.1",
+    "default_suffix": "fsdp",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/mistral/mixtral/mixtral-qlora-fsdp.yml"
+  },
+  {
+    "id": "mistral/mixtral/mixtral",
+    "family": "mistral",
+    "family_label": "Mistral",
+    "label": "Mistral \u2022 Mixtral 8X7B V0.1",
+    "base_model": "mistralai/Mixtral-8x7B-v0.1",
+    "default_suffix": "mixtral",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/mistral/mixtral/mixtral.yml"
+  },
+  {
+    "id": "orpheus/finetune",
+    "family": "orpheus",
+    "family_label": "Orpheus",
+    "label": "Orpheus \u2022 Orpheus 3B 0.1 Pretrained",
+    "base_model": "canopylabs/orpheus-3b-0.1-pretrained",
+    "default_suffix": "finetune",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/orpheus/finetune.yml"
+  },
+  {
+    "id": "phi/phi-ft",
+    "family": "phi",
+    "family_label": "Phi",
+    "label": "Phi \u2022 Phi 1 5",
+    "base_model": "microsoft/phi-1_5",
+    "default_suffix": "ft",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/phi/phi-ft.yml"
+  },
+  {
+    "id": "phi/phi-qlora",
+    "family": "phi",
+    "family_label": "Phi",
+    "label": "Phi \u2022 Phi 1 5",
+    "base_model": "microsoft/phi-1_5",
+    "default_suffix": "qlora",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/phi/phi-qlora.yml"
+  },
+  {
+    "id": "phi/phi2-ft",
+    "family": "phi",
+    "family_label": "Phi",
+    "label": "Phi \u2022 Phi 2",
+    "base_model": "microsoft/phi-2",
+    "default_suffix": "phi2",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/phi/phi2-ft.yml"
+  },
+  {
+    "id": "phi/phi3-ft-fsdp",
+    "family": "phi",
+    "family_label": "Phi",
+    "label": "Phi \u2022 Phi 3 Mini 4K Instruct",
+    "base_model": "microsoft/Phi-3-mini-4k-instruct",
+    "default_suffix": "phi3",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/phi/phi3-ft-fsdp.yml"
+  },
+  {
+    "id": "phi/phi3-ft",
+    "family": "phi",
+    "family_label": "Phi",
+    "label": "Phi \u2022 Phi 3 Mini 4K Instruct",
+    "base_model": "microsoft/Phi-3-mini-4k-instruct",
+    "default_suffix": "phi3",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/phi/phi3-ft.yml"
+  },
+  {
+    "id": "phi/lora-3.5",
+    "family": "phi",
+    "family_label": "Phi",
+    "label": "Phi \u2022 Phi 3.5 Mini Instruct",
+    "base_model": "microsoft/Phi-3.5-mini-instruct",
+    "default_suffix": "3.5",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/phi/lora-3.5.yaml"
+  },
+  {
+    "id": "pixtral/lora-12b",
+    "family": "pixtral",
+    "family_label": "Pixtral",
+    "label": "Pixtral \u2022 Pixtral 12B",
+    "base_model": "mistral-community/pixtral-12b",
+    "default_suffix": "12b",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/pixtral/lora-12b.yml"
+  },
+  {
+    "id": "qwen2/qlora-fsdp",
+    "family": "qwen2",
+    "family_label": "QWEN2",
+    "label": "QWEN2 \u2022 QWEN2 7B",
+    "base_model": "Qwen/Qwen2-7B",
+    "default_suffix": "fsdp",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/qwen2/qlora-fsdp.yaml"
+  },
+  {
+    "id": "qwen2/dpo",
+    "family": "qwen2",
+    "family_label": "QWEN2",
+    "label": "QWEN2 \u2022 QWEN2.5 0.5B",
+    "base_model": "Qwen/Qwen2.5-0.5B",
+    "default_suffix": "dpo",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/qwen2/dpo.yaml"
+  },
+  {
+    "id": "qwen2/reward-model",
+    "family": "qwen2",
+    "family_label": "QWEN2",
+    "label": "QWEN2 \u2022 QWEN2.5 0.5B",
+    "base_model": "Qwen/Qwen2.5-0.5B",
+    "default_suffix": "model",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/qwen2/reward-model.yaml"
+  },
+  {
+    "id": "qwen2/prm",
+    "family": "qwen2",
+    "family_label": "QWEN2",
+    "label": "QWEN2 \u2022 QWEN2.5 3B",
+    "base_model": "Qwen/Qwen2.5-3B",
+    "default_suffix": "prm",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/qwen2/prm.yaml"
+  },
+  {
+    "id": "qwen2_5-vl/lora-7b",
+    "family": "qwen2_5-vl",
+    "family_label": "QWEN2 5 Vl",
+    "label": "QWEN2 5 Vl \u2022 QWEN2.5 VL 7B Instruct",
+    "base_model": "Qwen/Qwen2.5-VL-7B-Instruct",
+    "default_suffix": "7b",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/qwen2_5-vl/lora-7b.yaml"
+  },
+  {
+    "id": "qwen2-vl/lora-7b",
+    "family": "qwen2-vl",
+    "family_label": "QWEN2 Vl",
+    "label": "QWEN2 Vl \u2022 QWEN2 VL 7B Instruct",
+    "base_model": "Qwen/Qwen2-VL-7B-Instruct",
+    "default_suffix": "7b",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/qwen2-vl/lora-7b.yaml"
+  },
+  {
+    "id": "qwen3/32b-qlora",
+    "family": "qwen3",
+    "family_label": "QWEN3",
+    "label": "QWEN3 \u2022 QWEN3 32B",
+    "base_model": "Qwen/Qwen3-32B",
+    "default_suffix": "32b",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/qwen3/32b-qlora.yaml"
+  },
+  {
+    "id": "qwen3/8b-qat-fsdp2",
+    "family": "qwen3",
+    "family_label": "QWEN3",
+    "label": "QWEN3 \u2022 QWEN3 8B",
+    "base_model": "Qwen/Qwen3-8B",
+    "default_suffix": "fsdp2",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/qwen3/8b-qat-fsdp2.yml"
+  },
+  {
+    "id": "qwen3/qlora-fsdp",
+    "family": "qwen3",
+    "family_label": "QWEN3",
+    "label": "QWEN3 \u2022 QWEN3 8B",
+    "base_model": "Qwen/Qwen3-8B",
+    "default_suffix": "fsdp",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/qwen3/qlora-fsdp.yaml"
+  },
+  {
+    "id": "qwen3/reward-model",
+    "family": "qwen3",
+    "family_label": "QWEN3",
+    "label": "QWEN3 \u2022 Skywork Reward V2 QWEN3 8B",
+    "base_model": "Skywork/Skywork-Reward-V2-Qwen3-8B",
+    "default_suffix": "model",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/qwen3/reward-model.yaml"
+  },
+  {
+    "id": "qwen3-next/qwen3-next-80b-a3b-qlora",
+    "family": "qwen3-next",
+    "family_label": "QWEN3 Next",
+    "label": "QWEN3 Next \u2022 QWEN3 Next 80B A3B Instruct",
+    "base_model": "Qwen/Qwen3-Next-80B-A3B-Instruct",
+    "default_suffix": "a3b",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/qwen3-next/qwen3-next-80b-a3b-qlora.yaml"
+  },
+  {
+    "id": "seed-oss/seed-oss-36b-qlora",
+    "family": "seed-oss",
+    "family_label": "Seed Oss",
+    "label": "Seed Oss \u2022 Seed OSS 36B Instruct",
+    "base_model": "ByteDance-Seed/Seed-OSS-36B-Instruct",
+    "default_suffix": "36b",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/seed-oss/seed-oss-36b-qlora.yaml"
+  },
+  {
+    "id": "smolvlm2/smolvlm2-2B-lora",
+    "family": "smolvlm2",
+    "family_label": "SMOLVLM2",
+    "label": "SMOLVLM2 \u2022 SMOLVLM2 2.2B Instruct",
+    "base_model": "HuggingFaceTB/SmolVLM2-2.2B-Instruct",
+    "default_suffix": "2B",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/smolvlm2/smolvlm2-2B-lora.yaml"
+  },
+  {
+    "id": "streaming/pretrain",
+    "family": "streaming",
+    "family_label": "Streaming",
+    "label": "Streaming \u2022 SMOLLM2 135M",
+    "base_model": "HuggingFaceTB/SmolLM2-135M",
+    "default_suffix": "pretrain",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/streaming/pretrain.yaml"
+  },
+  {
+    "id": "streaming/sft",
+    "family": "streaming",
+    "family_label": "Streaming",
+    "label": "Streaming \u2022 SMOLLM2 135M",
+    "base_model": "HuggingFaceTB/SmolLM2-135M",
+    "default_suffix": "sft",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/streaming/sft.yaml"
+  },
+  {
+    "id": "voxtral/voxtral-mini-audio-qlora",
+    "family": "voxtral",
+    "family_label": "Voxtral",
+    "label": "Voxtral \u2022 Voxtral Mini 3B 2507",
+    "base_model": "mistralai/Voxtral-Mini-3B-2507",
+    "default_suffix": "qlora",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/voxtral/voxtral-mini-audio-qlora.yml"
+  },
+  {
+    "id": "voxtral/voxtral-mini-qlora",
+    "family": "voxtral",
+    "family_label": "Voxtral",
+    "label": "Voxtral \u2022 Voxtral Mini 3B 2507",
+    "base_model": "mistralai/Voxtral-Mini-3B-2507",
+    "default_suffix": "qlora",
+    "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/voxtral/voxtral-mini-qlora.yml"
+  }
+]

--- a/app/services/config_builder.py
+++ b/app/services/config_builder.py
@@ -67,8 +67,18 @@ def build_training_config(
 
     method_defaults = DEFAULT_METHOD_PARAMETERS.get(training_method, {})
 
+    model_option = OPEN_SOURCE_MODELS.get(base_model)
+    if not model_option and params.get("model_choice_id"):
+        model_option = OPEN_SOURCE_MODELS.get(params["model_choice_id"])
+
+    resolved_base_model = params.get("resolved_base_model")
+    if not resolved_base_model and model_option:
+        resolved_base_model = model_option.resolved_base_model
+    if not resolved_base_model:
+        resolved_base_model = base_model
+
     config: dict[str, Any] = {
-        "base_model": base_model,
+        "base_model": resolved_base_model,
         "datasets": [
             {
                 "path": dataset_path,
@@ -116,7 +126,9 @@ def build_training_config(
             "o_proj",
         ])
 
-    reference = OPEN_SOURCE_MODELS.get(base_model, {}).get("reference_config")
+    reference = params.get("model_reference_config")
+    if not reference and model_option:
+        reference = model_option.reference_config
     if reference:
         config["reference_config"] = reference
 

--- a/app/services/constants.py
+++ b/app/services/constants.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import json
+from collections import defaultdict, OrderedDict
+from pathlib import Path
+from typing import Iterable
 
 
 @dataclass(frozen=True)
@@ -8,6 +12,66 @@ class TrainingMethod:
     id: str
     label: str
     description: str
+
+
+@dataclass(frozen=True)
+class ModelOption:
+    id: str
+    family: str
+    family_label: str
+    label: str
+    base_model: str | None
+    default_suffix: str | None
+    reference_config: str | None
+
+    @property
+    def resolved_base_model(self) -> str:
+        return self.base_model or self.id
+
+    def to_choice(self) -> dict[str, str | None]:
+        return {
+            "label": self.label,
+            "family": self.family,
+            "family_label": self.family_label,
+            "base_model": self.base_model,
+            "default_suffix": self.default_suffix,
+            "reference_config": self.reference_config,
+        }
+
+
+def _load_open_source_models() -> dict[str, ModelOption]:
+    data_path = Path(__file__).resolve().parent.parent / "data" / "open_source_models.json"
+    try:
+        with data_path.open("r", encoding="utf-8") as fp:
+            raw_models: Iterable[dict[str, str]] = json.load(fp)
+    except FileNotFoundError:  # pragma: no cover - defensive fallback
+        return {}
+
+    models: dict[str, ModelOption] = {}
+    for entry in raw_models:
+        option = ModelOption(
+            id=entry.get("id", ""),
+            family=entry.get("family", "misc"),
+            family_label=entry.get("family_label", entry.get("family", "Misc")),
+            label=entry.get("label", entry.get("id", "")),
+            base_model=entry.get("base_model"),
+            default_suffix=entry.get("default_suffix"),
+            reference_config=entry.get("reference_config"),
+        )
+        if option.id:
+            models[option.id] = option
+    return models
+
+
+def group_models_by_family(models: dict[str, ModelOption]) -> OrderedDict[str, list[ModelOption]]:
+    grouped: defaultdict[str, list[ModelOption]] = defaultdict(list)
+    for option in models.values():
+        grouped[option.family_label or option.family].append(option)
+
+    ordered: OrderedDict[str, list[ModelOption]] = OrderedDict()
+    for family, options in sorted(grouped.items(), key=lambda item: item[0].lower()):
+        ordered[family] = sorted(options, key=lambda opt: opt.label.lower())
+    return ordered
 
 
 TRAINING_METHODS: list[TrainingMethod] = [
@@ -18,30 +82,4 @@ TRAINING_METHODS: list[TrainingMethod] = [
 ]
 
 
-OPEN_SOURCE_MODELS: dict[str, dict[str, str]] = {
-    "gpt-oss-20b": {
-        "label": "GPT-OSS 20B",
-        "default_suffix": "20b",
-        "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/tree/main/examples/gpt-oss/gpt-oss-20b-fft-fsdp2.yaml",
-    },
-    "mpt-7b": {
-        "label": "MPT 7B",
-        "default_suffix": "7b",
-        "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/tree/main/examples/mpt",
-    },
-    "llama-3-8b": {
-        "label": "Llama 3 8B",
-        "default_suffix": "8b",
-        "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/tree/main/examples/llama-3",
-    },
-    "phi-3-4b": {
-        "label": "Phi-3 4B",
-        "default_suffix": "4b",
-        "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/tree/main/examples/phi-3",
-    },
-    "NousResearch/Llama-3.2-1B": {
-        "label": "Llama-3.2-1B",
-        "default_suffix": "1b",
-        "reference_config": "https://github.com/axolotl-ai-cloud/axolotl/tree/main/examples/llama-3/lora-1b.yml",
-    }
-}
+OPEN_SOURCE_MODELS: dict[str, ModelOption] = _load_open_source_models()

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -95,6 +95,11 @@ body {
   gap: 0.5rem;
 }
 
+.field-label {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
 label {
   font-weight: 600;
   font-size: 0.95rem;
@@ -123,6 +128,28 @@ textarea:focus {
   outline: none;
   border-color: var(--accent);
   box-shadow: 0 0 0 3px rgba(109, 135, 255, 0.25);
+}
+
+.dataset-source-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.dataset-source-options label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-weight: 500;
+}
+
+.dataset-source-options input[type="radio"] {
+  accent-color: var(--accent);
+}
+
+[data-dataset-existing] select:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
 }
 
 .hint {
@@ -196,6 +223,20 @@ textarea:focus {
   flex-direction: column;
   gap: 0.5rem;
   font-weight: 500;
+}
+
+.tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  margin-left: 0.5rem;
+  padding: 0.15rem 0.55rem;
+  border-radius: 999px;
+  background: rgba(109, 135, 255, 0.18);
+  color: var(--accent);
+  font-size: 0.7rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
 }
 
 .checkbox {

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -26,17 +26,38 @@
       <div class="field-group">
         <label for="base_model">Base model</label>
         <select id="base_model" name="base_model" required>
-          {% for key, info in models.items() %}
-            <option value="{{ key }}">{{ info.label }}</option>
+          {% for family, options in model_groups.items() %}
+            <optgroup label="{{ family }}">
+              {% for option in options %}
+                <option value="{{ option.id }}">{{ option.label }}</option>
+              {% endfor %}
+            </optgroup>
           {% endfor %}
         </select>
         <small class="hint">Reference configs sourced from Axolotl examples.</small>
       </div>
 
       <div class="field-group">
+        <span class="field-label">Dataset source</span>
+        <div class="dataset-source-options">
+          <label><input type="radio" name="dataset_mode" value="upload" checked /> Upload new dataset</label>
+          <label><input type="radio" name="dataset_mode" value="existing" /> Use stored dataset</label>
+        </div>
+        <small class="hint">Reuse previously uploaded datasets without re-uploading files.</small>
+      </div>
+
+      <div class="field-group" data-dataset-upload>
         <label for="dataset">Training dataset</label>
-        <input type="file" id="dataset" name="dataset" accept=".json,.jsonl,.yaml,.yml" required />
+        <input type="file" id="dataset" name="dataset" accept=".json,.jsonl,.yaml,.yml" />
         <small class="hint">Upload chat_template formatted data (<a href="{{ dataset_help_url }}" target="_blank">learn more</a>).</small>
+      </div>
+
+      <div class="field-group" data-dataset-existing hidden>
+        <label for="existing_dataset">Stored datasets</label>
+        <select id="existing_dataset" name="existing_dataset" data-empty-option="No stored datasets yet" disabled>
+          <option value="">Loading datasets…</option>
+        </select>
+        <small class="hint" data-existing-empty hidden>Upload a dataset to populate this list.</small>
       </div>
 
       <details class="advanced-options">
@@ -73,13 +94,14 @@
     </div>
     <div id="jobs-list" class="jobs-list" data-empty="No fine-tuning jobs yet. Create one to get started.">
       {% for job in jobs %}
+        {% set model_label = job.parameters.get('model_label') if job.parameters else None %}
         <article class="job-card" data-job-id="{{ job.id }}">
           <header>
             <h3>{{ job.display_name }}</h3>
             <span class="status status-{{ job.status.value }}">{{ job.status.value|capitalize }}</span>
           </header>
           <dl>
-            <div><dt>Model</dt><dd>{{ job.base_model }}</dd></div>
+            <div><dt>Model</dt><dd>{{ model_label or job.base_model }}</dd></div>
             <div><dt>Method</dt><dd>{{ job.training_method|upper }}</dd></div>
             <div><dt>Created</dt><dd>{{ job.created_at.strftime('%Y-%m-%d %H:%M') }}</dd></div>
           </dl>

--- a/app/templates/job_detail.html
+++ b/app/templates/job_detail.html
@@ -9,14 +9,24 @@
       <h2>{{ job.display_name }}</h2>
       <span class="status status-{{ job.status.value }}">{{ job.status.value|capitalize }}</span>
     </header>
+    {% set model_label = job.parameters.get('model_label') if job.parameters else None %}
+    {% set dataset_mode = job.parameters.get('dataset_mode') if job.parameters else 'upload' %}
+    {% set dataset_name = job.parameters.get('dataset_storage_name') if job.parameters else job.dataset_path %}
+    {% set resolved_model = job.parameters.get('resolved_base_model') if job.parameters else job.base_model %}
+    {% set reference_config = job.parameters.get('model_reference_config') if job.parameters else None %}
     <dl>
-      <div><dt>Base model</dt><dd>{{ job.base_model }}</dd></div>
+      <div><dt>Model</dt><dd>{{ model_label or resolved_model }}</dd></div>
+      <div><dt>Base model ID</dt><dd><code>{{ resolved_model }}</code></dd></div>
       <div><dt>Training method</dt><dd>{{ job.training_method|upper }}</dd></div>
       <div><dt>Created</dt><dd>{{ job.created_at.strftime('%Y-%m-%d %H:%M:%S') }}</dd></div>
       <div><dt>Started</dt><dd>{{ job.started_at.strftime('%Y-%m-%d %H:%M:%S') if job.started_at else '—' }}</dd></div>
       <div><dt>Completed</dt><dd>{{ job.completed_at.strftime('%Y-%m-%d %H:%M:%S') if job.completed_at else '—' }}</dd></div>
-      <div><dt>Dataset</dt><dd><code>{{ job.dataset_path }}</code></dd></div>
+      <div><dt>Dataset file</dt><dd>{{ dataset_name }}{% if dataset_mode == 'existing' %}<span class="tag">Reused</span>{% endif %}</dd></div>
+      <div><dt>Dataset path</dt><dd><code>{{ job.dataset_path }}</code></dd></div>
       <div><dt>Config</dt><dd><code>{{ job.config_path }}</code></dd></div>
+      {% if reference_config %}
+        <div><dt>Reference config</dt><dd><a href="{{ reference_config }}" target="_blank" rel="noopener">{{ reference_config }}</a></dd></div>
+      {% endif %}
       <div><dt>Command</dt><dd><code>{{ job.docker_command }}</code></dd></div>
     </dl>
   </div>


### PR DESCRIPTION
## Summary
- move the open-source model catalog into a generated JSON file and load it through a typed helper
- surface the expanded catalog in the UI with grouped selections and improved metadata in job views
- add dataset reuse support, including an API to list uploads and frontend controls to pick stored datasets

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4ac082fa88330a0a4cb353cfab5d5