### PR TITLE
Fix detached TrainingJob access in background thread

### DIFF
--- a/app/services/training.py
+++ b/app/services/training.py
@@ -268,8 +268,10 @@ def _run_training_job(app, job_id: int) -> None:
         job.append_event(f"Running command: {command}")
         db.session.commit()
 
+    log_path_str = str(log_path)
+
     try:
-        with open(job.log_path, "a", encoding="utf-8") as log_file:
+        with open(log_path_str, "a", encoding="utf-8") as log_file:
             process = subprocess.Popen(
                 command,
                 shell=True,


### PR DESCRIPTION
## Summary
- cache the training job log path string before leaving the app context
- use the cached log path when streaming subprocess output so detached SQLAlchemy objects are not accessed

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d766cbc1f08330b0e758f6638fa217